### PR TITLE
Add observers to GraphQL

### DIFF
--- a/etc/graphql/events.xml
+++ b/etc/graphql/events.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Karliuka Vitalii(karliuka.vitalii@gmail.com)
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <!-- event catalog_product_is_salable_after -->
+    <event name="catalog_product_is_salable_after">
+        <observer name="faonni_product_available" instance="Faonni\ProductAvailable\Observer\SalableObserver"/>
+    </event>
+    <!-- event sales_quote_product_add_after -->
+    <event name="sales_quote_product_add_after">
+        <observer name="faonni_product_available" instance="Faonni\ProductAvailable\Observer\QuoteObserver"/>
+    </event>
+    <!-- event catalog_product_collection_load_after -->
+    <event name="catalog_product_collection_load_after">
+        <observer name="faonni_product_available" instance="Faonni\ProductAvailable\Observer\CollectionObserver"/>
+    </event>
+    <!-- event catalog_product_load_after -->
+    <event name="catalog_product_load_after">
+        <observer name="faonni_product_available" instance="Faonni\ProductAvailable\Observer\ProductObserver"/>
+    </event>
+</config>


### PR DESCRIPTION
I'm not sure if this is all required, but graphql falls outside the frontend scope, see https://devdocs.magento.com/guides/v2.4/ext-best-practices/extension-coding/observers-bp.html

See https://github.com/magento/magento2/pull/29998

Not sure if it's hidden correctly, but it looks like it atleast hides the prices or makes it zero.